### PR TITLE
Downgraded dotnetcore to 2.0

### DIFF
--- a/InterviewTest.Tests/InterviewTest.Tests.csproj
+++ b/InterviewTest.Tests/InterviewTest.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/InterviewTest/InterviewTest.csproj
+++ b/InterviewTest/InterviewTest.csproj
@@ -1,7 +1,7 @@
 <Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>NancyTemplate</AssemblyName>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
This will provide broader support for the target development station, it also gets rid of the difference in targeted frameworks between the projects.